### PR TITLE
Source slack bugfix incorrect thread ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.1-airbyte
+    * Fixed thread_ts overwrite for each message.
+    * Formatted thread_ts as ISO date.
+    [#1][https://github.com/airbytehq/tap-slack/pull/1]
+
 ## 1.0.0
     * Added some streams, changed the name of some streams [#9](https://github.com/singer-io/tap-slack/pull/9)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.0.1-airbyte
     * Fixed thread_ts overwrite for each message.
-    * Formatted thread_ts as ISO date.
+    * Formatted thread_ts as ISO date in threads and messages streams.
     [#1][https://github.com/airbytehq/tap-slack/pull/1]
 
 ## 1.0.0

--- a/tap_slack/schemas/messages.json
+++ b/tap_slack/schemas/messages.json
@@ -299,7 +299,8 @@
       "type": [
         "null",
         "string"
-      ]
+      ],
+      "format": "date-time"
     },
     "topic": {
       "type": [

--- a/tap_slack/schemas/threads.json
+++ b/tap_slack/schemas/threads.json
@@ -70,7 +70,8 @@
       "type": [
         "null",
         "string"
-      ]
+      ],
+      "format": "date-time"
     },
     "reply_count": {
       "type": [

--- a/tap_slack/streams.py
+++ b/tap_slack/streams.py
@@ -390,6 +390,8 @@ class ThreadsStream(SlackStream):
                                                          date_fields=self.date_fields,
                                                          channel_id=channel_id)
                     for message in transformed_threads:
+                        if message['thread_ts']:
+                            message['thread_ts'] = message['thread_ts'].partition('.')[0]
                         with singer.Transformer(
                                 integer_datetime_fmt="unix-seconds-integer-datetime-parsing") \
                                 as transformer:

--- a/tap_slack/streams.py
+++ b/tap_slack/streams.py
@@ -269,8 +269,8 @@ class ConversationHistoryStream(SlackStream):
                                             integer_datetime_fmt=
                                             "unix-seconds-integer-datetime-parsing"
                                     ) as transformer:
-                                        record_timestamp = data['thread_ts'].partition('.')[0]
-                                        if data['thread_ts']:
+                                        if data.get('thread_ts'):
+                                            record_timestamp = data['thread_ts'].partition('.')[0]
                                             data['thread_ts'] = record_timestamp
                                         transformed_record = transformer.transform(
                                             data=data,
@@ -390,7 +390,7 @@ class ThreadsStream(SlackStream):
                                                          date_fields=self.date_fields,
                                                          channel_id=channel_id)
                     for message in transformed_threads:
-                        if message['thread_ts']:
+                        if message.get('thread_ts'):
                             message['thread_ts'] = message['thread_ts'].partition('.')[0]
                         with singer.Transformer(
                                 integer_datetime_fmt="unix-seconds-integer-datetime-parsing") \

--- a/tap_slack/streams.py
+++ b/tap_slack/streams.py
@@ -269,14 +269,14 @@ class ConversationHistoryStream(SlackStream):
                                             integer_datetime_fmt=
                                             "unix-seconds-integer-datetime-parsing"
                                     ) as transformer:
+                                        record_timestamp = data['thread_ts'].partition('.')[0]
+                                        if data['thread_ts']:
+                                            data['thread_ts'] = record_timestamp
                                         transformed_record = transformer.transform(
                                             data=data,
                                             schema=schema,
                                             metadata=metadata.to_map(mdata)
                                         )
-                                        record_timestamp = \
-                                            transformed_record.get('thread_ts', '').partition('.')[
-                                                0]
                                         record_timestamp_int = int(record_timestamp)
                                         if record_timestamp_int >= start.timestamp():
                                             if self.write_to_singer:

--- a/tap_slack/transform.py
+++ b/tap_slack/transform.py
@@ -9,6 +9,7 @@ def decimal_timestamp_to_utc_timestamp(timestamp):
 def transform_json(stream, data, date_fields, channel_id=None):
 
     if data:
+        thread_ts = None
         for record in data:
             if stream == "messages":
                 # Strip out file info and just keep id
@@ -34,8 +35,10 @@ def transform_json(stream, data, date_fields, channel_id=None):
                 timestamp = record.get(date_field, None)
                 if timestamp and isinstance(timestamp, str):
                     if stream == 'messages' or stream == "threads" and date_field == 'ts':
-                        record['thread_ts'] = timestamp
                         record[date_field] = decimal_timestamp_to_utc_timestamp(timestamp)
+                        if thread_ts is None:
+                            thread_ts = timestamp
+                        record['thread_ts'] = thread_ts
                     else:
                         record[date_field] = decimal_timestamp_to_utc_timestamp(timestamp)
     return data

--- a/tap_slack/transform.py
+++ b/tap_slack/transform.py
@@ -9,7 +9,6 @@ def decimal_timestamp_to_utc_timestamp(timestamp):
 def transform_json(stream, data, date_fields, channel_id=None):
 
     if data:
-        thread_ts = None
         for record in data:
             if stream == "messages":
                 # Strip out file info and just keep id
@@ -31,14 +30,16 @@ def transform_json(stream, data, date_fields, channel_id=None):
                 record.pop("parent_conversation", None)
                 record.pop("channel_id", None)
 
+            # Set the date field value for all streams
+            # Set record["thread_ts"] = record.get(date_field, None) in "messages" stream
+            # Set record["thread_ts"] to first data record date_field value in "threads" stream,
+            # so record["thread_ts"] equals to first message ts in thread
             for date_field in date_fields:
                 timestamp = record.get(date_field, None)
                 if timestamp and isinstance(timestamp, str):
-                    if stream == 'messages' or stream == "threads" and date_field == 'ts':
-                        record[date_field] = decimal_timestamp_to_utc_timestamp(timestamp)
-                        if thread_ts is None:
-                            thread_ts = timestamp
-                        record['thread_ts'] = thread_ts
-                    else:
-                        record[date_field] = decimal_timestamp_to_utc_timestamp(timestamp)
+                    if stream == "messages":
+                        record["thread_ts"] = timestamp
+                    elif stream == "threads" and date_field == "ts":
+                        record["thread_ts"] = data[0].get("thread_ts", None)
+                    record[date_field] = decimal_timestamp_to_utc_timestamp(timestamp)
     return data

--- a/tap_slack/transform.py
+++ b/tap_slack/transform.py
@@ -30,16 +30,13 @@ def transform_json(stream, data, date_fields, channel_id=None):
                 record.pop("parent_conversation", None)
                 record.pop("channel_id", None)
 
-            # Set the date field value for all streams
-            # Set record["thread_ts"] = record.get(date_field, None) in "messages" stream
-            # Set record["thread_ts"] to first data record date_field value in "threads" stream,
-            # so record["thread_ts"] equals to first message ts in thread
+            # Set date field value for all streams
+            # Set "thread_ts" to record value in "messages" stream
+            # Do not change "thread_ts" value for other streams
             for date_field in date_fields:
                 timestamp = record.get(date_field, None)
                 if timestamp and isinstance(timestamp, str):
                     if stream == "messages":
                         record["thread_ts"] = timestamp
-                    elif stream == "threads" and date_field == "ts":
-                        record["thread_ts"] = data[0].get("thread_ts", None)
                     record[date_field] = decimal_timestamp_to_utc_timestamp(timestamp)
     return data


### PR DESCRIPTION
# Description of change
Fix `thread_ts` overwrite and apply ISO time format.

# Manual QA steps
Run python `main_dev.py read --config secrets/config.json --catalog sample_files/configured_catalog.json` and check output records.
 
# Risks
Not sure why it was `thread_ts` overwrite previously, perhaps we may miss some of the sync data.
 
# Rollback steps
 - revert this branch